### PR TITLE
Added Support for Data-Annotation validation in non-module referenced Assemblies

### DIFF
--- a/AdminMenu.cs
+++ b/AdminMenu.cs
@@ -11,14 +11,15 @@ namespace Q42.DbTranslations
 
     public void GetNavigation(NavigationBuilder builder)
     {
-      builder
-        .AddImageSet("Translations")
-        .Add(T("Translations"), "20", menu => menu.Action("Index", "Admin", new { area = "Q42.DbTranslations" })
-          .Add(T("Translate"), "0", item => item.Action("Index", "Admin", new { area = "Q42.DbTranslations" }).LocalNav())
-          .Add(T("Import"), "1", item => item.Action("Import", "Admin", new { area = "Q42.DbTranslations" }).LocalNav())
-          .Add(T("Export"), "2", item => item.Action("Export", "Admin", new { area = "Q42.DbTranslations" }).LocalNav())
-          .Add(T("Search"), "3", item => item.Action("Search", "Admin", new { area = "Q42.DbTranslations" }).LocalNav())
-        );
+        builder
+          .AddImageSet("Translations")
+          .Add(T("Translations"), "20", menu => menu.Action("Index", "Admin", new { area = "Q42.DbTranslations" })
+            .Add(T("Translate"), "0", item => item.Action("Index", "Admin", new { area = "Q42.DbTranslations" }).LocalNav())
+            .Add(T("Import"), "1", item => item.Action("Import", "Admin", new { area = "Q42.DbTranslations" }).LocalNav())
+            .Add(T("Export"), "2", item => item.Action("Export", "Admin", new { area = "Q42.DbTranslations" }).LocalNav())
+            .Add(T("Search"), "3", item => item.Action("Search", "Admin", new { area = "Q42.DbTranslations" }).LocalNav())
+            .Add(T("Extra"), "4", item => item.Action("Extra", "Admin", new { area = "Q42.DbTranslations"}).LocalNav())
+          );
     }
 
   }

--- a/Q42.DbTranslations.csproj
+++ b/Q42.DbTranslations.csproj
@@ -137,6 +137,7 @@
     <Content Include="Views\Admin\Culture.cshtml" />
     <Content Include="Views\Admin\Details.cshtml" />
     <Content Include="Views\Admin\Index.cshtml" />
+    <Content Include="Views\Admin\Extra.cshtml" />
     <Content Include="Content\form-invalid.gif" />
     <Content Include="Content\form-valid.gif" />
     <Content Include="Content\icon_download.png" />

--- a/Services/LocalizationManagementService.cs
+++ b/Services/LocalizationManagementService.cs
@@ -8,6 +8,8 @@ using Fluent.Zip;
 using Orchard;
 using Q42.DbTranslations.Models;
 using Path = Fluent.IO.Path;
+using System.ComponentModel.DataAnnotations;
+using Orchard.Localization;
 
 namespace Q42.DbTranslations.Services
 {
@@ -16,6 +18,7 @@ namespace Q42.DbTranslations.Services
         void InstallTranslation(byte[] zippedTranslation, string sitePath);
         byte[] PackageTranslations(string cultureCode, string sitePath);
         IEnumerable<StringEntry> ExtractDefaultTranslation(string sitePath, string targetSitePath);
+        IEnumerable<StringEntry> ExtractTranslationsFromAssembly(string assemblyName, string moduleName);
         void SyncTranslation(string sitePath, string cultureCode);
     }
 
@@ -74,6 +77,60 @@ namespace Q42.DbTranslations.Services
                 translationFiles,
                 p => site.Combine(p).ReadBytes());
         }
+
+        /// <summary>
+        /// This method goes through an selected assembly to get all data-Annotations (validation) for that assembly. 
+        /// </summary>
+        /// <param name="assemblyName">The name (not fullname) of the referenced Assembly</param>
+        /// <param name="moduleName">The name (not fullname) of the module where the keys are needed</param>
+        /// <returns>A list of StringEntries to be instered into the Q42 DB</returns>
+        public IEnumerable<StringEntry> ExtractTranslationsFromAssembly(string assemblyName, string moduleName)
+        {
+            var result = new List<StringEntry>();
+
+            var stringList = new List<string>();
+            //declarations
+            var referencedAssembly = AppDomain.CurrentDomain.GetAssemblies().Where(e => e.FullName.Contains(assemblyName)).FirstOrDefault();
+            var annotationList = new List<string> {"Required", "RegularExpression", "Range", "StringLength" };
+            var path = GetModuleLocalizationPath(null, moduleName).Replace('\\', '/');
+
+
+            //Get the Data-Annotations Error Msgs for the Assembly using Reflection
+            if(referencedAssembly != null){
+            var Types = referencedAssembly.GetTypes();
+            foreach (var t in Types)
+            {
+                var properties = t.GetProperties();
+                foreach (var propertyInfo in properties)
+                {
+                    foreach (var customAttr in propertyInfo.GetCustomAttributesData())
+                    {
+                       if(annotationList.Any(customAttr.Constructor.DeclaringType.Name.Contains))
+                       {
+                           var firstOrDefault = customAttr.NamedArguments.Where(i => i.MemberInfo.Name.ToString() == "ErrorMessage").Select(i => i.TypedValue.Value).FirstOrDefault();
+                           if (firstOrDefault != null)
+                           {
+                               var key = (firstOrDefault.ToString()
+                                         );
+                               result.Add(new StringEntry
+                                              {
+                                                  Culture = null,
+                                                  Context = t.FullName,
+                                                  Key = key,
+                                                  English = key,
+                                                  Translation = key,
+                                                  Path = path
+                                              });
+                           }
+                       }
+                    }
+                }
+            }
+            }
+
+            //done --> return result
+            return result;
+        } 
 
         public IEnumerable<StringEntry> ExtractDefaultTranslation(string sitePath, string targetSitePath)
         {

--- a/Views/Admin/Extra.cshtml
+++ b/Views/Admin/Extra.cshtml
@@ -1,0 +1,49 @@
+﻿@using System.Globalization
+
+@{
+  Layout.Title = "Database translations";
+}
+
+
+<div class="content">
+    <h2>@T("Generate from referenced Assemblies")</h2>
+    <p>@T("This will get the translation keys for DataAnnotations from the referenced Assemblies. Select the module, then select the referenced Assembly you want to parse")</p>
+    <p>
+        <form action="@Url.Action("Extra")" method="get">
+            <select id="modules" name="moduleName">
+                @foreach (var module in ViewBag.Modules)
+                {
+                    if(module.Name == ViewBag.selectedModule)
+                     {
+                      <option value="@module.Name" selected="selected">@module.Name</option>   
+                     }
+                    else
+                    {
+                        <option value="@module.Name">@module.Name</option>
+                    }
+                }
+            </select>
+            <input type="submit" class="button" name="submit" value="@T("Get Assemblies")" />
+        </form>
+    </p>
+    @{
+        if (ViewBag.Assemblies != null)
+        {
+            <p>
+                <form action="@Url.Action("FromAssembly")" method="get">
+                    <input type="hidden" name="selectedModule" value="@ViewBag.selectedModule"/>
+                    <select id="modules" name="referencedAssemblyName">
+                        @foreach (var assemblyName in ViewBag.Assemblies)
+                        {
+                            <option value="@assemblyName.Name">@assemblyName.Name</option>
+                        }
+                    </select>
+                    <input type="submit" class="button" name="submit" value="@T("Get keys from Assembly")" />
+                </form>
+            </p>
+        }
+    }
+    
+</div>
+<p>&nbsp;</p>
+  


### PR DESCRIPTION
We'va added an addition to your code in order to be able to import translations of the data-annotations error messages for referenced assemblies of modules.

it's added in an extra tab to your admin menu but, you are offcourse free to place it where-ever you want (just added it there to keep it a bit seperated).

We hope this can be helpfull to you guys  as it was/is to us.

Krikke999 & LievenVandeperre 
